### PR TITLE
Make healthcheck standard and available

### DIFF
--- a/.github/workflows/workflow-pr-close.yml
+++ b/.github/workflows/workflow-pr-close.yml
@@ -1,4 +1,4 @@
-name: PR Workflow
+name: PR Closed Workflow
 
 on:
   pull_request:

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -117,7 +117,7 @@ paths:
         type: "aws_proxy"
         contentHandling: "CONVERT_TO_TEXT"
 
-  /health:
+  /health-check:
     get:
       operationId: healthCheck
       summary: Health check endpoint for external services to consume
@@ -145,7 +145,7 @@ paths:
                     example: Unhealthy
                 additionalProperties: false
       x-amazon-apigateway-auth:
-        type: "AWS_IAM"
+        type: "NONE"
       x-amazon-apigateway-integration:
         type: "mock"
         responses:

--- a/go.work.sum
+++ b/go.work.sum
@@ -22,4 +22,5 @@ golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
 golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/terraform/environment/region/apigateway.tf
+++ b/terraform/environment/region/apigateway.tf
@@ -129,6 +129,19 @@ data "aws_iam_policy_document" "lpa_store" {
     actions   = ["execute-api:Invoke"]
     resources = ["*"]
   }
+
+  statement {
+    sid    = "AllowHealthCheckExecutionFromAnyone"
+    effect = "Allow"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions   = ["execute-api:Invoke"]
+    resources = ["execute-api:/${local.stage_name}/GET/health-check"]
+  }
 }
 
 resource "aws_lambda_permission" "api_gateway_invoke" {


### PR DESCRIPTION
Move the health check to our [standard path](https://docs.opg.service.justice.gov.uk/documentation/adrs/adr-007.html) and remove authentication so it can be called from anywhere.

#minor